### PR TITLE
reprebot/feat: #20 use fake-list-chat-model

### DIFF
--- a/src/llm_client/__init__.py
+++ b/src/llm_client/__init__.py
@@ -6,6 +6,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain.docstore.document import Document
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import FakeEmbeddings
+from langchain.chat_models.fake import FakeListChatModel
 
 class LLMClient:
     def __init__(self, model_type: str):
@@ -22,14 +23,16 @@ class LLMClient:
                 model_name="gpt-3.5-turbo-0125",
                 temperature=temperature
             )
+        elif self.model_type == "fake":
+            model = FakeListChatModel(responses=["Hello",])
         """
         elif self.model_type == "hugging-face":
             llm = HuggingFaceEndpoint(
                 repo_id="google/gemma-7b",
             )
             model = ChatHuggingFace(llm=llm)
-        """
         # https://github.com/langchain-ai/langchain/issues/18639
+        """
         return model
 
     def setup_chain(self, retriever, prompt, model):

--- a/test/unit/src/test_llm_client.py
+++ b/test/unit/src/test_llm_client.py
@@ -6,20 +6,20 @@ from langchain.docstore.document import Document
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_core.runnables.base import RunnableSequence
+from langchain.chat_models.fake import FakeListChatModel
 
-class TestLLMClient:
+
+class TestFakeLLMClient:
     @pytest.fixture
     def llm_client(self):
-        return LLMClient(model_type="gpt")
+        return LLMClient(model_type="fake")
 
     def test_init(self, llm_client):
-        assert llm_client.openai_api_key == os.environ.get("OPENAI_API_KEY")
-        assert llm_client.model_type == "gpt"
+        assert llm_client.model_type == "fake"
 
     def test_setup_model(self, llm_client):
-        temperature = 0.5
-        model = llm_client.setup_model(temperature=temperature)
-        assert model.temperature == temperature
+        model = llm_client.setup_model()
+        assert isinstance(model, FakeListChatModel)
 
     def test_setup_chain(self, llm_client):
         # Empty retriever for testing
@@ -29,15 +29,13 @@ class TestLLMClient:
         ).as_retriever(search_kwargs={"k": 1})
         # Empty prompt for testing
         prompt = ChatPromptTemplate.from_messages([""])
-        # Default "gpt" model use in this test
+        # Default "fake" model use in this test
         model = llm_client.setup_model()
         # RAG chain
         chain = llm_client.setup_chain(retriever=retriever, prompt=prompt, model=model)
         assert isinstance(chain, RunnableSequence)
 
     def test_query(self, llm_client):
-        # This test is currently using GPT model
-        # Ideally we should use a free model for this
-        # We will try to do that in the future
         response = llm_client.query(user_input="")
         assert isinstance(response, str)
+        assert response == "Hello"


### PR DESCRIPTION
- use `FakeListChatModel` to instantiate fake models for testing
- remove `gpt` model unit test
- add `fake` model unit test
- note: with this, we won't incur in costs when running unit tests