### PR TITLE
reprebot/refac: #30 use fp in llm client module

### DIFF
--- a/src/llm_client/__init__.py
+++ b/src/llm_client/__init__.py
@@ -10,54 +10,44 @@ from langchain.chat_models.fake import FakeListChatModel
 from langchain_community.chat_models.huggingface import ChatHuggingFace
 from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 
-class LLMClient:
-    def __init__(self, model_type: str):
-        self.openai_api_key = os.environ.get("OPENAI_API_KEY")
-        self.huggingfacehub_api_token = os.environ.get("HUGGINGFACEHUB_API_TOKEN")
-        self.model_type = model_type
-        self.model = self.setup_model()
-
-    def setup_model(self, temperature=0):
-        model = None
-        if self.model_type == "gpt":
-            model = ChatOpenAI(
-                api_key=self.openai_api_key,
-                model_name="gpt-3.5-turbo-0125",
-                temperature=temperature
-            )
-        elif self.model_type == "fake":
-            model = FakeListChatModel(responses=["Hello",])
-        elif self.model_type == "hugging-face":
-            llm = HuggingFaceEndpoint(
-                repo_id="google/gemma-7b",
-            )
-            model = ChatHuggingFace(llm=llm)
-        return model
-
-    def setup_chain(self, retriever, prompt, model):
-        chain = (
-            {
-                "input": RunnablePassthrough(),
-                "context": retriever,
-            }
-            | prompt
-            | model
-            | StrOutputParser()
+def setup_model(model_type: str, temperature: float = 0):
+    model = None
+    if model_type == "gpt":
+        model = ChatOpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY"),
+            model_name="gpt-3.5-turbo-0125",
+            temperature=temperature
         )
-        return chain
-
-    def query(self, user_input: str):
-        # Empty retriever for testing
-        retriever = Chroma.from_documents(
-            documents=[Document(page_content="")],
-            embedding=FakeEmbeddings(size=1),
-        ).as_retriever(search_kwargs={"k": 1})
-        # Empty prompt for testing
-        prompt = ChatPromptTemplate.from_messages([""])
-        chain = self.setup_chain(
-            retriever=retriever,
-            prompt=prompt,
-            model=self.model
+    elif model_type == "fake":
+        model = FakeListChatModel(responses=["Hello"])
+    elif model_type == "hugging-face":
+        llm = HuggingFaceEndpoint(
+            repo_id="google/gemma-7b",
         )
-        response = chain.invoke(user_input)
-        return response
+        model = ChatHuggingFace(llm=llm)
+    return model
+
+def setup_chain(retriever, prompt, model):
+    chain = (
+        {
+            "input": RunnablePassthrough(),
+            "context": retriever,
+        }
+        | prompt
+        | model
+        | StrOutputParser()
+    )
+    return chain
+
+def query(user_input: str, model_type: str):
+    # Empty retriever for testing
+    retriever = Chroma.from_documents(
+        documents=[Document(page_content="")],
+        embedding=FakeEmbeddings(size=1),
+    ).as_retriever(search_kwargs={"k": 1})
+    # Empty prompt for testing
+    prompt = ChatPromptTemplate.from_messages([""])
+    model = setup_model(model_type)
+    chain = setup_chain(retriever=retriever, prompt=prompt, model=model)
+    response = chain.invoke(user_input)
+    return response

--- a/test/unit/src/test_llm_client.py
+++ b/test/unit/src/test_llm_client.py
@@ -1,5 +1,4 @@
-import pytest
-from src.llm_client import LLMClient
+from src.llm_client import setup_model, setup_chain, query
 from langchain.prompts import ChatPromptTemplate
 from langchain.docstore.document import Document
 from langchain_community.vectorstores import Chroma
@@ -8,65 +7,39 @@ from langchain_core.runnables.base import RunnableSequence
 from langchain.chat_models.fake import FakeListChatModel
 from langchain_community.chat_models.huggingface import ChatHuggingFace
 
+def test_setup_model_fake():
+    model = setup_model("fake")
+    assert isinstance(model, FakeListChatModel)
 
-class TestFakeLLMClient:
-    @pytest.fixture
-    def llm_client(self):
-        return LLMClient(model_type="fake")
+def test_setup_model_hugging_face():
+    model = setup_model("hugging-face")
+    assert isinstance(model, ChatHuggingFace)
 
-    def test_init(self, llm_client):
-        assert llm_client.model_type == "fake"
+def test_setup_chain_fake():
+    retriever = Chroma.from_documents(
+        documents=[Document(page_content="")],
+        embedding=FakeEmbeddings(size=1),
+    ).as_retriever(search_kwargs={"k": 1})
+    prompt = ChatPromptTemplate.from_messages([""])
+    model = setup_model("fake")
+    chain = setup_chain(retriever=retriever, prompt=prompt, model=model)
+    assert isinstance(chain, RunnableSequence)
 
-    def test_setup_model(self, llm_client):
-        model = llm_client.setup_model()
-        assert isinstance(model, FakeListChatModel)
+def test_setup_chain_hugging_face():
+    retriever = Chroma.from_documents(
+        documents=[Document(page_content="")],
+        embedding=FakeEmbeddings(size=1),
+    ).as_retriever(search_kwargs={"k": 1})
+    prompt = ChatPromptTemplate.from_messages([""])
+    model = setup_model("hugging-face")
+    chain = setup_chain(retriever=retriever, prompt=prompt, model=model)
+    assert isinstance(chain, RunnableSequence)
 
-    def test_setup_chain(self, llm_client):
-        # Empty retriever for testing
-        retriever = Chroma.from_documents(
-            documents=[Document(page_content="")],
-            embedding=FakeEmbeddings(size=1),
-        ).as_retriever(search_kwargs={"k": 1})
-        # Empty prompt for testing
-        prompt = ChatPromptTemplate.from_messages([""])
-        # Default "fake" model use in this test
-        model = llm_client.setup_model()
-        # RAG chain
-        chain = llm_client.setup_chain(retriever=retriever, prompt=prompt, model=model)
-        assert isinstance(chain, RunnableSequence)
+def test_query_fake():
+    response = query(user_input="", model_type="fake")
+    assert isinstance(response, str)
+    assert response == "Hello"
 
-    def test_query(self, llm_client):
-        response = llm_client.query(user_input="")
-        assert isinstance(response, str)
-        assert response == "Hello"
-
-
-class TestHuggingFaceLLMClient:
-    @pytest.fixture
-    def llm_client(self):
-        return LLMClient(model_type="hugging-face")
-
-    def test_init(self, llm_client):
-        assert llm_client.model_type == "hugging-face"
-
-    def test_setup_model(self, llm_client):
-        model = llm_client.setup_model()
-        assert isinstance(model, ChatHuggingFace)
-
-    def test_setup_chain(self, llm_client):
-        # Empty retriever for testing
-        retriever = Chroma.from_documents(
-            documents=[Document(page_content="")],
-            embedding=FakeEmbeddings(size=1),
-        ).as_retriever(search_kwargs={"k": 1})
-        # Empty prompt for testing
-        prompt = ChatPromptTemplate.from_messages([""])
-        # Default "fake" model use in this test
-        model = llm_client.setup_model()
-        # RAG chain
-        chain = llm_client.setup_chain(retriever=retriever, prompt=prompt, model=model)
-        assert isinstance(chain, RunnableSequence)
-
-    def test_query(self, llm_client):
-        response = llm_client.query(user_input="")
-        assert isinstance(response, str)
+def test_query_hugging_face():
+    response = query(user_input="", model_type="hugging-face")
+    assert isinstance(response, str)


### PR DESCRIPTION
- refactor `llm_client` module to use FP instead of OOP
- refactor `test_llm_client` module to use FP instead of OOP