### PR TITLE
reprebot/refac: #30 parameterize llm client module

### DIFF
--- a/src/llm_client/types.py
+++ b/src/llm_client/types.py
@@ -1,0 +1,17 @@
+
+class GPTModelConfig: # pragma: no cover
+    def __init__(self, model_name: str, temperature: float = 0.00):
+        self.model_type: str = "gpt"
+        self.model_name = model_name
+        self.temperature = temperature
+
+class FakeModelConfig:
+    def __init__(self, responses: list[str]):
+        self.model_type: str = "fake"
+        self.responses = responses
+
+class HuggingFaceModelConfig:
+    def __init__(self, repo_id: str, temperature: float = 0.01):
+        self.model_type: str = "hugging-face"
+        self.repo_id = repo_id
+        self.temperature = temperature


### PR DESCRIPTION
- add model config types to llm client module
- add setup model functions for each type of model
- test each type of model: hugging-face, fake, gpt
- add skip conditions to models that depend on tokens
- add skip decorator to gpt test
- parameterize tests with pytest decorators