### PR TITLE
reprebot/refac: #34 use sha256 hash for docs ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Reprebot relies on the following dependencies:
 - `beautifulsoup4`
 - `chromadb`
 - `coverage`
+- `cryptography`
 - `Jinja2`
 - `langchain`
 - `langchain-openai`

--- a/direct-requirements.txt
+++ b/direct-requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.12.3
 chromadb==0.4.24
 coverage==7.4.4
+cryptography==42.0.5
 Jinja2==3.1.3
 langchain==0.1.12
 langchain-openai==0.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ beautifulsoup4==4.12.3
 build==1.1.1
 cachetools==5.3.3
 certifi==2024.2.2
+cffi==1.16.0
 charset-normalizer==3.3.2
 chroma-hnswlib==0.7.3
 chromadb==0.4.24
@@ -17,6 +18,7 @@ click==8.1.7
 colorama==0.4.6
 coloredlogs==15.0.1
 coverage==7.4.4
+cryptography==42.0.5
 dataclasses-json==0.6.4
 Deprecated==1.2.14
 distro==1.9.0
@@ -79,6 +81,7 @@ protobuf==4.25.3
 pulsar-client==3.4.0
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
+pycparser==2.21
 pydantic==2.6.4
 pydantic_core==2.16.3
 PyPika==0.48.9

--- a/src/context_builder/faculty_secretary_faq/main.py
+++ b/src/context_builder/faculty_secretary_faq/main.py
@@ -1,7 +1,7 @@
 from typing import List
 import requests
 from bs4 import BeautifulSoup
-import hashlib
+from cryptography.hazmat.primitives import hashes
 import os
 from pathlib import Path
 
@@ -20,8 +20,10 @@ def setup_folder(folder: str = os.path.join(PROJECT_ROOT, 'data/faculty_secretar
 
 
 def write_file(text: str, folder: str = os.path.join(PROJECT_ROOT, 'data/faculty_secretary_faq')) -> None:
-    md5_hash = hashlib.md5(text.encode()).hexdigest()
-    with open(f"{folder}/{md5_hash}.txt", "w", encoding="utf-8") as file:
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(text.encode())
+    file_name = digest.finalize().hex()
+    with open(f"{folder}/{file_name}.txt", "w", encoding="utf-8") as file:
         file.write(text)
 
 

--- a/test/unit/src/test_faculty_secretary_faq.py
+++ b/test/unit/src/test_faculty_secretary_faq.py
@@ -1,5 +1,5 @@
 import os
-import hashlib
+from cryptography.hazmat.primitives import hashes
 from typing import List
 from bs4 import BeautifulSoup
 import pytest
@@ -58,7 +58,9 @@ def test_setup_folder(folder: str):
 def test_write_file(folder: str, text: str):
     setup_folder(folder=folder)
     write_file(text=text, folder=folder)
-    file_name = hashlib.md5(text.encode()).hexdigest()
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(text.encode())
+    file_name = digest.finalize().hex()
     file_path = f'{folder}/{file_name}.txt'
     assert os.path.exists(file_path)
     shutil.rmtree(folder)


### PR DESCRIPTION
- add `cryptography` dependency
- use `SHA256` instead of `MD5` to identify the documents