### PR TITLE
reprebot/refac: #5 add vector store config parameter

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3,7 +3,7 @@ import sys
 sys.path.append('../..')
 from src.llm_client import query as _query
 from src.llm_client.types import GPTModelConfig
-
+from src.vector_store.types import VectorStoreConfig
 
 app = FastAPI()
 
@@ -11,11 +11,17 @@ model_config = GPTModelConfig(
     model_name="gpt-3.5-turbo-0125",
 )
 
+vector_store_config = VectorStoreConfig(
+    embeddings="OPENAI",
+    retriever="FULL",
+)
+
 @app.get("/{query}")
 async def query(query):
     response = _query(
         user_input=query,
-        model_config=model_config
+        model_config=model_config,
+        vector_store_config=vector_store_config
     )
     print(response)
     return response

--- a/src/llm_client/__init__.py
+++ b/src/llm_client/__init__.py
@@ -9,6 +9,7 @@ from langchain_community.embeddings import FakeEmbeddings
 from langchain.chat_models.fake import FakeListChatModel
 from langchain_community.chat_models.huggingface import ChatHuggingFace
 from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
+from src.vector_store.types import VectorStoreConfig
 from .types import (
     GPTModelConfig,
     FakeModelConfig,
@@ -82,10 +83,11 @@ def setup_prompt(messages):
 
 def query(
         user_input: str,
-        model_config: GPTModelConfig | FakeModelConfig | HuggingFaceModelConfig
+        model_config: GPTModelConfig | FakeModelConfig | HuggingFaceModelConfig,
+        vector_store_config: VectorStoreConfig,
     ):
     # we temporarily return vector db to check if docs are being retrieved
-    retriever, vector_db = setup_retriever()
+    retriever, vector_db = setup_retriever(config=vector_store_config)
     docs = vector_db.similarity_search(user_input)
     # no docs are being retrieved yet for some reason
     # we need to check if it's something related to the chunking technique

--- a/src/vector_store/types.py
+++ b/src/vector_store/types.py
@@ -1,0 +1,19 @@
+
+
+from enum import Enum
+from typing import NamedTuple
+
+
+class RetrieverEnum(Enum):
+    EMPTY = 'EMPTY'
+    FULL = 'FULL'
+
+
+class EmbeddingsEnum(Enum):
+    FAKE = 'FAKE'
+    OPENAI = 'OPENAI'
+
+
+class VectorStoreConfig(NamedTuple):
+    retriever: RetrieverEnum
+    embeddings: EmbeddingsEnum

--- a/test/unit/src/test_llm_client.py
+++ b/test/unit/src/test_llm_client.py
@@ -8,9 +8,11 @@ from src.llm_client.types import (
     FakeModelConfig,
     HuggingFaceModelConfig,
 )
+from src.vector_store.types import (
+    VectorStoreConfig,
+)
 
 
-@pytest.mark.skip(reason="can't use empty retriever yet")
 @pytest.mark.parametrize(
     ("user_input", "responses"),
     [
@@ -23,12 +25,19 @@ def test_query_fake(user_input: str, responses: list[str]):
     model_config = FakeModelConfig(
         responses=responses,
     )
-    response = query(user_input=user_input, model_config=model_config)
+    vector_store_config = VectorStoreConfig(
+        retriever="EMPTY",
+        embeddings="FAKE",
+    )
+    response = query(
+        user_input=user_input,
+        model_config=model_config,
+        vector_store_config=vector_store_config,
+    )
     assert isinstance(response, str)
     assert response in responses
 
 
-@pytest.mark.skip(reason="can't use empty retriever yet")
 @pytest.mark.skipif(
     os.environ.get("HUGGINGFACEHUB_API_TOKEN") is None,
     reason="HUGGINGFACEHUB_API_TOKEN is not available"
@@ -43,7 +52,15 @@ def test_query_hugging_face(user_input: str, repo_id: str):
     model_config = HuggingFaceModelConfig(
         repo_id=repo_id,
     )
-    response = query(user_input=user_input, model_config=model_config)
+    vector_store_config = VectorStoreConfig(
+        retriever="EMPTY",
+        embeddings="FAKE",
+    )
+    response = query(
+        user_input=user_input,
+        model_config=model_config,
+        vector_store_config=vector_store_config,
+    )
     assert isinstance(response, str)
 
 
@@ -63,6 +80,14 @@ def test_query_gpt(user_input: str, _word_to_check: str):
     model_config = GPTModelConfig(
         model_name="gpt-3.5-turbo-0125",
     )
-    response = query(user_input=user_input, model_config=model_config)
+    vector_store_config = VectorStoreConfig(
+        retriever="FULL",
+        embeddings="OPENAI",
+    )
+    response = query(
+        user_input=user_input,
+        model_config=model_config,
+        vector_store_config=vector_store_config,
+    )
     assert isinstance(response, str)
     assert _word_to_check in response


### PR DESCRIPTION
- add `VectorStoreConfig` type
- add `vector_store_config` param to `query`
- add `setup_full_retriever` function
- add `setup_embeddings` function
- re-enable llm client unit tests