### PR TITLE
reprebot/refac: #4 format faculty-secreatry-faq context builder text

### DIFF
--- a/src/context_builder/faculty_secretary_faq/main.py
+++ b/src/context_builder/faculty_secretary_faq/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 sys.path.append('../../..')
 from src.constants import CONTEXT_DATA_PATHS
+import re
 
 
 FOLDER = CONTEXT_DATA_PATHS["faculty_secretary_faq"]
@@ -29,15 +30,24 @@ def write_file(text: str, folder: str = FOLDER) -> None:
         file.write(text)
 
 
+def format_text(text: str) -> str:
+    formatted_text = re.sub(r'\s+', ' ', text).strip()
+    return formatted_text
+
+
 def assemble_text(button):
-    button_text = button.get_text()
+    button_text = format_text(button.get_text())
     next_div = button.find_next_sibling('div')
     if next_div:
-        div_text = next_div.get_text()
+        div_text = format_text(next_div.get_text())
         anchors = next_div.find_all('a')
-        href_values = [anchor['href'] for anchor in anchors]
-        combined_text = div_text + "\n" + "\n".join(href_values)
-        text = f"{button_text}\n{combined_text}\n"
+        href_text = "\n".join([
+            f"[{format_text(anchor.get_text())}]({anchor['href']})"
+            for anchor in anchors
+        ])
+        href_text = "\n\nENLACES:\n" + href_text if len(href_text) > 0 else href_text
+        combined_text = f"{div_text}{href_text}"
+        text = f"{button_text}\n\n{combined_text}\n"
         return text
 
 

--- a/src/llm_client/__init__.py
+++ b/src/llm_client/__init__.py
@@ -19,6 +19,7 @@ from src.vector_store import setup_retriever
 
 MESSAGES = [
     ("system", "Use the context to give an accurate answer to the user query."),
+    ("system", "If you find any URL in the context, include them in your response."),
     ("system", "context: {context}"),
     ("user", "query: {input}"),
 ]
@@ -85,6 +86,9 @@ def query(
     ):
     # we temporarily return vector db to check if docs are being retrieved
     retriever = setup_retriever(config=vector_store_config)
+    # we will find a feature to return information about the sources
+    # for enhanced transparency and to check if there are any hallucinations
+    # docs = retriever.get_relevant_documents(query=user_input)
     prompt = setup_prompt(messages=MESSAGES)
     model = setup_model(model_config=model_config)
     chain = setup_chain(retriever=retriever, prompt=prompt, model=model)

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ response = query(
     vector_store_config=vector_store_config
 )
 
-print(response)
+print(response, "\n")
 
 response = query(
     user_input="""
@@ -33,4 +33,26 @@ response = query(
     vector_store_config=vector_store_config
 )
 
-print(response)
+print(response, "\n")
+
+
+response = query(
+    user_input="""
+        ¿Cuándo puedo cancelar materias? Tienes enlaces relacionados con este proceso?
+    """,
+    model_config=model_config,
+    vector_store_config=vector_store_config
+)
+
+print(response, "\n")
+
+
+response = query(
+    user_input="""
+        ¿Cuál es la diferencia entre práctica y pasantía?
+    """,
+    model_config=model_config,
+    vector_store_config=vector_store_config
+)
+
+print(response, "\n")

--- a/test/unit/src/test_faculty_secretary_faq.py
+++ b/test/unit/src/test_faculty_secretary_faq.py
@@ -70,7 +70,7 @@ def test_write_file(folder: str, text: str):
 @pytest.mark.parametrize(
     ("_text"),
     [
-        ("Button 1\nContent 1 Link 1\nlink1\n"),
+        ("Button 1\n\nContent 1 Link 1\n\nENLACES:\n[Link 1](link1)\n"),
     ],
 )
 def test_assemble_text(_text: str):
@@ -84,12 +84,13 @@ def test_assemble_text(_text: str):
     [
         (
             [
-                "Button 1\nContent 1 Link 1\nlink1\n",
-                "Button 2\nContent 2 Link 2\nlink2\n",
+                "Button 1\n\nContent 1 Link 1\n\nENLACES:\n[Link 1](link1)\n",
+                "Button 2\n\nContent 2 Link 2\n\nENLACES:\n[Link 2](link2)\n",
             ]
         ),
     ],
 )
 def test_extract_texts(_texts: List[str]):
     texts = extract_texts(html=MOCK_HTML)
+    print(texts)
     assert texts == _texts


### PR DESCRIPTION
- add `format_text` function to `faculty_secretary_faq` context builder script to remove extra spaces
- modify unit tests accordingly
- modify llm client prompt to ask the model to include URLs if it find any #5
- explore `get_relevant_documents` function to get information about sources
- add more example queries to `main.py`