### PR TITLE
reprebot/feat: #4 add metadata to documents

### DIFF
--- a/src/constants/__init__.py
+++ b/src/constants/__init__.py
@@ -11,4 +11,10 @@ CONTEXT_DATA_PATHS = {
 }
 
 
+# might be useful for CRUD
+CONTEXT_DATA_SOURCES = {
+    "faculty_secretary_faq": "https://ingenieria.bogota.unal.edu.co/es/dependencias/secretaria-academica/preguntas-frecuentes.html"
+}
+
+
 VECTOR_DATABASE_PATH = os.path.join(PROJECT_ROOT, "vectordb/")

--- a/test/unit/src/test_faculty_secretary_faq.py
+++ b/test/unit/src/test_faculty_secretary_faq.py
@@ -92,5 +92,4 @@ def test_assemble_text(_text: str):
 )
 def test_extract_texts(_texts: List[str]):
     texts = extract_texts(html=MOCK_HTML)
-    print(texts)
     assert texts == _texts


### PR DESCRIPTION
- stop using chunking
- add documents after creating vector store to get ids
- add metadata to documents when they are created
- add `CONTEXT_DATA_SOURCES` constant