### PR TITLE
reprebot/feat #5 add database to store docs metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 cobertura.xml
-
 data/
-
 vectordb/
+reprebot.db
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/constants/__init__.py
+++ b/src/constants/__init__.py
@@ -4,6 +4,11 @@ import os
 PROJECT_ROOT = str(Path(__file__).parent.parent.parent)
 
 
+CONTEXT_DATA_GROUPS = [
+    "faculty_secretary_faq",
+]
+
+
 CONTEXT_DATA_PATHS = {
     "faculty_secretary_faq": os.path.join(
         PROJECT_ROOT, "data/faculty_secretary_faq/"

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,0 +1,52 @@
+import sqlite3
+
+class Database:
+    def __init__(self, db_name: str) -> None:
+        self.connector = None
+        self.cursor = None
+        self.db_name = db_name
+        self._connect()
+        self._create_tables()
+
+
+    def _connect(self) -> None:
+        self.connector = sqlite3.connect(self.db_name)
+        self.cursor = self.connector.cursor()
+
+
+    def _create_tables(self) -> None:
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents(
+                id TEXT,
+                filename TEXT,
+                group_id INTEGER
+            )
+            """
+        )
+        self.connector.commit()
+
+
+    def _insert(self, data: list[tuple[str, str, str]]) -> None:
+        self.cursor.executemany(
+            "INSERT INTO documents VALUES (?, ?, ?)",
+            data
+        )
+        self.connector.commit()
+
+
+    def push(self, ids, metadata) -> None:
+        data = [
+            (_id, _metadata["filename"], _metadata["group_id"])
+            for _id, _metadata in zip(ids, metadata)
+        ]
+        self._insert(data)
+
+
+    def reset(self) -> None:
+        self.cursor.execute("DROP TABLE IF EXISTS documents")
+        self._create_tables()
+
+
+    def close(self) -> None:
+        self.connector.close()


### PR DESCRIPTION
- add `database` module to implement simple `sqlite3` database
- add `_push_metadata` function to `vector_store` module
- note: the purpose of this is to store the vector db id of each document and its filename to be able to map both ids. This would be useful for a CRUD of the vector store and the context data that allows us to get, add, delete and update documents in the vector store with the help of this simple SQL table which works as a simple map between the id and the filename. We store the `group_id` too which is the equivalent of the context folder (ie: `faculty_secretary_faq`)