### PR TITLE
reprebot/feat: #5 add vector store delete and update endpoints to api

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,6 +8,7 @@ from src.vector_store import get_document_by_filename
 from src.vector_store import get_document_by_id
 from src.vector_store import delete_document
 from src.vector_store import update_document
+from src.vector_store import add_document
 from langchain.docstore.document import Document
 
 
@@ -78,5 +79,20 @@ async def document_put(document_id: str = Query(None), page_content: str = Query
     else:
         response = {
             "error": "'document_id' and 'page_content' parameters must be provided.",
+        }
+    return response
+
+
+@app.post("/document")
+async def document_post(page_content: str = Query(None), group_id: int = Query(None)):
+    if page_content and group_id is not None:
+        document = Document(page_content=page_content)
+        document_id = add_document(document, group_id, vector_store_config)
+        response = {
+            "success": document_id,
+        }
+    else:
+        response = {
+            "error": "'page_content' and 'group_id' parameters must be provided.",
         }
     return response

--- a/src/constants/__init__.py
+++ b/src/constants/__init__.py
@@ -24,3 +24,4 @@ CONTEXT_DATA_SOURCES = {
 
 VECTOR_DATABASE_PATH = os.path.join(PROJECT_ROOT, "vectordb/")
 DATABASE_PATH = os.path.join(PROJECT_ROOT, "reprebot.db")
+CONTEXT_DATA_PATH = os.path.join(PROJECT_ROOT, "data/")

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -35,11 +35,41 @@ class Database:
         self.connector.commit()
 
 
+    def delete(self, document_id: str) -> None:
+        self.cursor.execute(
+            "DELETE FROM documents WHERE id = ?",
+            (document_id, )
+        )
+        self.connector.commit()
+
+
+    def update_filename(self, document_id: str, filename: str) -> None:
+        self.cursor.execute(
+            "UPDATE documents SET filename = ? WHERE id = ?",
+            (filename, document_id,)
+        )
+        self.connector.commit()
+
+
     def get_id_by_filename(self, filename: str) -> str:
         self.cursor.execute("SELECT id FROM documents WHERE filename = ?", (filename,))
         result = self.cursor.fetchone()
         _id = result[0]
         return _id
+
+
+    def get_filename_by_id(self, document_id: str) -> str:
+        self.cursor.execute("SELECT filename FROM documents WHERE id = ?", (document_id,))
+        result = self.cursor.fetchone()
+        filename = result[0]
+        return filename
+
+
+    def get_group_id_by_id(self, document_id: str) -> str:
+        self.cursor.execute("SELECT group_id FROM documents WHERE id = ?", (document_id,))
+        result = self.cursor.fetchone()
+        group_id = result[0]
+        return group_id
 
 
     def push(self, ids, metadata) -> None:

--- a/src/vector_store/__init__.py
+++ b/src/vector_store/__init__.py
@@ -15,7 +15,9 @@ from src.constants import VECTOR_DATABASE_PATH
 from src.constants import DATABASE_PATH
 from src.constants import CONTEXT_DATA_PATHS
 from src.constants import CONTEXT_DATA_GROUPS
+from src.constants import CONTEXT_DATA_PATH
 from src.database import Database
+from cryptography.hazmat.primitives import hashes
 
 
 def load_documents_from_file(filepath: str) -> List[Document]:
@@ -146,7 +148,26 @@ def get_document_by_id(document_id: str):
 
 def delete_document(document_id: str):
     vector_db = load_vector_database()
+    # remove vector
     vector_db.delete([document_id])
+    database = Database(db_name=DATABASE_PATH)
+    # remove file
+    filename = database.get_filename_by_id(document_id)
+    group_id = database.get_group_id_by_id(document_id)
+    group = CONTEXT_DATA_GROUPS[group_id]
+    filepath = os.path.join(CONTEXT_DATA_PATH, group, filename)
+    os.remove(filepath)
+    # remove db record
+    database.delete(document_id)
+
+
+def _write_file(text: str, folder: str) -> str:
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(text.encode())
+    file_name = digest.finalize().hex()
+    with open(f"{folder}/{file_name}.txt", "w", encoding="utf-8") as file:
+        file.write(text)
+    return f"{file_name}.txt"
 
 
 def update_document(document_id: str, document: Document, config: VectorStoreConfig):
@@ -155,8 +176,38 @@ def update_document(document_id: str, document: Document, config: VectorStoreCon
     old_document = vector_db.get(document_id)
     document.metadata = old_document["metadatas"][0]
     vector_db.update_document(document_id, document)
-    # re-calculate hash and rename txt file
+    database = Database(db_name=DATABASE_PATH)
+    # remove old file
+    old_filename = database.get_filename_by_id(document_id)
+    group_id = database.get_group_id_by_id(document_id)
+    group = CONTEXT_DATA_GROUPS[group_id]
+    folder = os.path.join(CONTEXT_DATA_PATH, group)
+    old_filepath = os.path.join(folder, old_filename)
+    os.remove(old_filepath)
+    # create new file
+    text = document.page_content
+    filename = _write_file(text, folder)
     # update database record filename
+    database.update_filename(document_id, filename)
 
-# add document: receive document and group
-# store document, generate txt file from content, add record to db
+
+def add_document(document: Document, group_id: int, config: VectorStoreConfig):
+    embedding_function = setup_embeddings(config)
+    vector_db = load_vector_database(embedding_function=embedding_function)
+    # generate file
+    group = CONTEXT_DATA_GROUPS[group_id]
+    folder = os.path.join(CONTEXT_DATA_PATH, group)
+    text = document.page_content
+    filename = _write_file(text, folder)
+    metadata = {
+        "filename": filename,
+        "group_id": group_id,
+    }
+    document.metadata = metadata
+    # insert vector
+    ids = vector_db.add_documents([document])
+    # create db record
+    database = Database(db_name=DATABASE_PATH)
+    database.push(ids, [metadata])
+    document_id = ids[0]
+    return document_id


### PR DESCRIPTION
- add `document_post` api endpoint
- add db `delete` operation
- add db `update_filename` operation
- add db `get_filename_by_id` operation
- add db `get_group_id_by_id` operation
- complete `delete_document` function
- complete `update_document` function
- add `_write_file` private function to `vector_store`
- add `add_document` function to `vector_store`