### PR TITLE
reprebot/refac: #7 add sources to chatbot responses

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,6 +1,17 @@
 import streamlit as st
 import requests
 
+with st.sidebar:
+    st.markdown(
+        """<div align="center">
+        <h3>Welcome to 🤖 <b>Reprebot</b>!</h3>
+        A chatbot to answer questions for the Faculty of Engineering community at the
+        National University of Colombia.
+        <br>
+        <a href="https://github.com/Represoft/reprebot">Source code</a>
+        """, unsafe_allow_html=True
+    )
+
 
 st.title("🤖 Reprebot")
 
@@ -20,11 +31,17 @@ if prompt := st.chat_input():
     st.session_state.messages.append({"role": "user", "content": prompt})
     st.chat_message("user").write(prompt)
 
-    response = requests.get("http://localhost:8000/query", params={"q": prompt})
+    response = requests.get("http://localhost:8000/query", params={"q": prompt}, timeout=12000)
     if response.status_code == 200:
-        msg = response.json()
+        result = response.json()
+        msg = result["response"]
     else:
         msg = "Oops! Ha ocurrido un error :("
 
     st.session_state.messages.append({"role": "assistant", "content": msg})
     st.chat_message("assistant").write(msg)
+    sources = result["sources"]
+    for i, source in enumerate(sources):
+        with st.expander(f"Fuente {i+1}"):
+            st.write(source["page_content"])
+            st.write(f"FUENTE: {source['source']}")

--- a/src/constants/__init__.py
+++ b/src/constants/__init__.py
@@ -16,7 +16,6 @@ CONTEXT_DATA_PATHS = {
 }
 
 
-# might be useful for CRUD
 CONTEXT_DATA_SOURCES = {
     "faculty_secretary_faq": "https://ingenieria.bogota.unal.edu.co/es/dependencias/secretaria-academica/preguntas-frecuentes.html"
 }

--- a/src/llm_client/types.py
+++ b/src/llm_client/types.py
@@ -1,4 +1,8 @@
 
+from typing import List, TypedDict
+from langchain.docstore.document import Document
+
+
 class GPTModelConfig: # pragma: no cover
     def __init__(self, model_name: str, temperature: float = 0.00):
         self.model_type: str = "gpt"
@@ -15,3 +19,13 @@ class HuggingFaceModelConfig:
         self.model_type: str = "hugging-face"
         self.repo_id = repo_id
         self.temperature = temperature
+
+
+class Source(TypedDict):
+    page_content: str
+    source: str
+
+
+class QueryResponse(TypedDict):
+    response: str
+    sources: List[Source]

--- a/test/unit/src/test_llm_client.py
+++ b/test/unit/src/test_llm_client.py
@@ -34,8 +34,8 @@ def test_query_fake(user_input: str, responses: list[str]):
         model_config=model_config,
         vector_store_config=vector_store_config,
     )
-    assert isinstance(response, str)
-    assert response in responses
+    assert isinstance(response["response"], str)
+    assert response["response"] in responses
 
 
 @pytest.mark.skipif(
@@ -61,7 +61,7 @@ def test_query_hugging_face(user_input: str, repo_id: str):
         model_config=model_config,
         vector_store_config=vector_store_config,
     )
-    assert isinstance(response, str)
+    assert isinstance(response["response"], str)
 
 
 # comment next line if you want to run this test
@@ -89,5 +89,5 @@ def test_query_gpt(user_input: str, _word_to_check: str):
         model_config=model_config,
         vector_store_config=vector_store_config,
     )
-    assert isinstance(response, str)
-    assert _word_to_check in response
+    assert isinstance(response["response"], str)
+    assert _word_to_check in response["response"]


### PR DESCRIPTION
- add `Source` and `QueryResponse` types
- return sources from `query` operation in `llm_client`
- add sidebar to chat interface
- display sources as an accordion in chat interface