### PR TITLE
reprebot/feat: #80 containerize application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env
+.venv
+*.db
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Make port 8501 (streamlit) and 8000 (fastapi) available to the world outside this container
+EXPOSE 8501 8000
+
+# Define environment variable
+ENV OPENAI_API_KEY=${OPENAI_API_KEY}
+ENV API_HOST=${API_HOST}
+
+# Run the entrypoint script when the container launches
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  api:
+    build: .
+    command: uvicorn main:app --reload --host 0.0.0.0 --port 8000
+    volumes:
+      - ./data:/app/data
+      - ./vectordb:/app/vectordb
+      - ./reprebot.db:/app/reprebot.db
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8000:8000"
+
+  streamlit:
+    build: .
+    command: bash -c "cd ../.. && streamlit run src/app/main.py"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - API_HOST=${API_HOST}
+    ports:
+      - "8501:8501"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Run the context builder scripts
+cd src/context_builder/faculty_secretary_faq && python main.py
+cd ../../..
+cd src/context_builder/faculty_secretary_students_requests && python main.py
+cd ../../..
+cd src/scripts && python setup_vector_store.py
+cd ../..
+cd src/api
+
+# Execute the command passed to the script
+exec "$@"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,5 +1,8 @@
 import streamlit as st
 import requests
+import os
+
+API_HOST = os.getenv("API_HOST", "localhost")
 
 st.set_page_config(page_title="🤖 Reprebot")
 
@@ -34,7 +37,7 @@ if prompt := st.chat_input():
     st.chat_message("user").write(prompt)
 
     response = requests.get(
-        "http://localhost:8000/query", params={"q": prompt}, timeout=12000
+        f"http://{API_HOST}:8000/query", params={"q": prompt}, timeout=12000
     )
     if response.status_code == 200:
         result = response.json()


### PR DESCRIPTION
- add `Dockerfile`
- add `docker-compose.yml` file
- add `entrypoint.sh` for `Dockerfile`
- add `.dockerignore` file
- modify streamlit app main file to use `API_HOST` env variable

**NOTES**:

- the `docker-compose.yml` file defines two services: api and streamlit app
- the streamlit app uses three volumes: data (context), vectordb and SQL db
- the `entrypoint.sh` script runs the setup commands: context builder and vector db setup
- the `exec` instruction in the `entrypoint.sh` runs the command passed by the services from `docker-compose.yml`
- the `Dockerfile` prepares the base image, sets up the working dir, install the reqs and runs the `entrypoint.sh` script
- the `API_HOST` env variable should be set to `api` in a `.env` file in the root of the project