### PR TITLE
reprebot/refac: #90 use dotenv in setup vector store script

### DIFF
--- a/src/scripts/setup_vector_store.py
+++ b/src/scripts/setup_vector_store.py
@@ -7,6 +7,9 @@ from src.vector_store import (
     load_documents_from_folders,
     setup_vector_database,
 )
+from dotenv import load_dotenv
+
+load_dotenv()
 
 config = VectorStoreConfig(
     embeddings="OPENAI",


### PR DESCRIPTION
- use `python-dotenv` in `setup_vector_database` to load env variable from `.env` file