### PR TITLE
reprebot/refac: #97 replace gpt-3.5 turbo model with gpt-4o mini model

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -17,7 +17,7 @@ app = FastAPI()
 
 
 model_config = GPTModelConfig(
-    model_name="gpt-3.5-turbo-0125",
+    model_name="gpt-4o-mini",
 )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from src.llm_client.types import GPTModelConfig
 from src.vector_store.types import VectorStoreConfig
 
 model_config = GPTModelConfig(
-    model_name="gpt-3.5-turbo-0125",
+    model_name="gpt-4o-mini",
 )
 
 vector_store_config = VectorStoreConfig(

--- a/test/unit/src/test_llm_client.py
+++ b/test/unit/src/test_llm_client.py
@@ -78,7 +78,7 @@ def test_query_hugging_face(user_input: str, repo_id: str):
 )
 def test_query_gpt(user_input: str, _word_to_check: str):
     model_config = GPTModelConfig(
-        model_name="gpt-3.5-turbo-0125",
+        model_name="gpt-4o-mini",
     )
     vector_store_config = VectorStoreConfig(
         retriever="FULL",


### PR DESCRIPTION
- pass `gpt-4o-mini` to `GPTModelConfig` in `api`
- pass `gpt-4o-mini` to `GPTModelConfig` in `test_llm_client`
- pass `gpt-4o-mini` to `GPTModelConfig` in demo `main` script